### PR TITLE
ADDING GITHUB CHAT MESSAGES

### DIFF
--- a/.github/workflows/github-messages.yml
+++ b/.github/workflows/github-messages.yml
@@ -32,7 +32,7 @@ jobs:
             New Pull Request!
             **Repository:** ${{ steps.get_pr_info.outputs.repo_name }}
             **Opened by:** ${{ steps.get_pr_info.outputs.pr_opener }}
-            **Required Approvals:** ${{ toJson(steps.get_pr_info.outputs) }}
+            **Required Approvals:** ${{ toJson(steps.get_pr_info) }}
             
       - name: Wait for Approvals
         uses: actions/github-script@v6

--- a/.github/workflows/github-messages.yml
+++ b/.github/workflows/github-messages.yml
@@ -32,7 +32,7 @@ jobs:
             New Pull Request!
             **Repository:** ${{ steps.get_pr_info.outputs.repo_name }}
             **Opened by:** ${{ steps.get_pr_info.outputs.pr_opener }}
-            **Required Approvals:** ${{ steps.get_pr_info.outputs }}
+            **Required Approvals:** ${{ toJson(steps.get_pr_info.outputs) }}
             
       - name: Wait for Approvals
         uses: actions/github-script@v6

--- a/.github/workflows/github-messages.yml
+++ b/.github/workflows/github-messages.yml
@@ -9,9 +9,7 @@ env:
 
 on:
   pull_request:
-    types:
-      - opened
-      - closed
+    types: [opened, reopened, synchronize, review_requested, ready_for_review, labeled, unlabeled]
   pull_request_review:
     types:
       - submitted

--- a/.github/workflows/github-messages.yml
+++ b/.github/workflows/github-messages.yml
@@ -28,7 +28,7 @@ jobs:
         uses: julb/action-post-googlechat-message@v1
         with:
           gchat_webhook_url: ${{ env.GCHAT_WEBHOOK_URL }}
-          message:
+          message: |
             New Pull Request!
             **Repository:** ${{ steps.get_pr_info.outputs.repo_name }}
             **Opened by:** ${{ steps.get_pr_info.outputs.pr_opener }}

--- a/.github/workflows/github-messages.yml
+++ b/.github/workflows/github-messages.yml
@@ -40,7 +40,7 @@ jobs:
 
             core.setOutput('approvals_count', pullRequest.reviews.filter(review => review.state === 'APPROVED').length);
 
-      - name: Send Approval Updates
+      - name: Send Approval Update
         uses: julb/action-post-googlechat-message@v1
         with:
           gchat_webhook_url: ${{ secrets.GCHAT_WEBHOOK_URL }}

--- a/.github/workflows/github-messages.yml
+++ b/.github/workflows/github-messages.yml
@@ -32,7 +32,7 @@ jobs:
             New Pull Request!
             **Repository:** ${{ steps.get_pr_info.outputs.repo_name }}
             **Opened by:** ${{ steps.get_pr_info.outputs.pr_opener }}
-            **Required Approvals:** ${{ steps.get_pr_info.outputs}}
+            **Required Approvals:** ${{ fromJson(steps.get_pr_info.outputs) }}
             
       - name: Wait for Approvals
         uses: actions/github-script@v6

--- a/.github/workflows/github-messages.yml
+++ b/.github/workflows/github-messages.yml
@@ -6,7 +6,7 @@ on:
     types:
       - submitted
 env:
-  REQUIRED_REVIEWS: 2
+  requested_reviewers: ${{ toJson(github.event.pull_request.requested_reviewers) }}
   GCHAT_WEBHOOK_URL: https://chat.googleapis.com/v1/spaces/AAAAu0pPs_8/messages?key=AIzaSyDdI0hCZtE6vySjMm-WEfRq3CPzqKqqsHI&token=2OA68qb_Xv29GMQUPkYHIb2Sm3e3AspjdZ7DAaeNQ0A
 
 jobs:
@@ -29,16 +29,17 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          APPROVED_COUNT=$(gh pr review ${{ github.event.pull_request.number }} state --jq '[.[] | select(.state=="APPROVED")] | length')
-          REQUIRED_REVIEWS=$(gh repo view --json pullRequests --jq '.pullRequests.nodes[].reviewRequests.totalCount')
-          if [ "$APPROVED_COUNT" -ge "$REQUIRED_REVIEWS" ]; then
-            echo "All required reviews are fulfilled. Proceeding to notify Google Chat."
-          else
-            echo "Not all required reviews are fulfilled yet."
-          fi
+          echo ${{ toJson(github.event.pull_request) }}
+          # APPROVED_COUNT=$(gh pr review ${{ github.event.pull_request.number }} state --jq '[.[] | select(.state=="APPROVED")] | length')
+          # REQUIRED_REVIEWS=$(gh repo view --json pullRequests --jq '.pullRequests.nodes[].reviewRequests.totalCount')
+          # if [ "$APPROVED_COUNT" -ge "$REQUIRED_REVIEWS" ]; then
+          #   echo "All required reviews are fulfilled. Proceeding to notify Google Chat."
+          # else
+          #   echo "Not all required reviews are fulfilled yet."
+          # fi
 
       - name: Notify Google Chat to Merge Code
-        if: github.event.action == 'submitted' && env.APPROVED_COUNT >= env.REQUIRED_REVIEWS
+        if: github.event.action == 'submitted' && env.APPROVED_COUNT >= REQUIRED_REVIEWS
         env:
           WEBHOOK_URL: ${{ env.GCHAT_WEBHOOK_URL }}
         run: |

--- a/.github/workflows/github-messages.yml
+++ b/.github/workflows/github-messages.yml
@@ -29,7 +29,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          APPROVED_COUNT=$(gh pr reviews ${{ github.event.pull_request.number }} state --jq '[.[] | select(.state=="APPROVED")] | length')
+          APPROVED_COUNT=$(gh pr review ${{ github.event.pull_request.number }} state --jq '[.[] | select(.state=="APPROVED")] | length')
           REQUIRED_REVIEWS=$(gh repo view --json pullRequests --jq '.pullRequests.nodes[].reviewRequests.totalCount')
           if [ "$APPROVED_COUNT" -ge "$REQUIRED_REVIEWS" ]; then
             echo "All required reviews are fulfilled. Proceeding to notify Google Chat."

--- a/.github/workflows/github-messages.yml
+++ b/.github/workflows/github-messages.yml
@@ -29,7 +29,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-        
+          echo gh api --header 'Accept: application/vnd.github+json' --method GET /repos/{owner}/{repo}/pulls/{pull_number}/reviews
           APPROVED_COUNT=$(gh api --header 'Accept: application/vnd.github+json' --method GET /repos/{owner}/{repo}/pulls/{pull_number}/reviews state --jq '[.[] | select(.state=="APPROVED")] | length')
           REQUIRED_REVIEWS=$(gh repo view --json pullRequests --jq '.pullRequests.nodes[].reviewRequests.totalCount')
           if [ "$APPROVED_COUNT" -ge "$REQUIRED_REVIEWS" ]; then

--- a/.github/workflows/github-messages.yml
+++ b/.github/workflows/github-messages.yml
@@ -1,48 +1,113 @@
-name: Pull Request Notifications
+
+name: Notify Google Chat on Pull Requests
+
 on:
   pull_request:
-    types: [opened, reopened, synchronize, review_requested, ready_for_review, labeled, unlabeled]
-  pull_request_review:
     types:
-      - submitted
-env:
-  requested_reviewers: ${{ toJson(github.event.pull_request.requested_reviewers) }}
-  GCHAT_WEBHOOK_URL: https://chat.googleapis.com/v1/spaces/AAAAu0pPs_8/messages?key=AIzaSyDdI0hCZtE6vySjMm-WEfRq3CPzqKqqsHI&token=2OA68qb_Xv29GMQUPkYHIb2Sm3e3AspjdZ7DAaeNQ0A
+      - opened
+      - synchronize
+      - review_requested
+      - review_submitted
 
 jobs:
   notify-google-chat:
     runs-on: ubuntu-latest
+
     steps:
-      # Notify when a PR is raised
-      - name: Notify Google Chat about PR Raised
-        if: github.event.action == 'opened'
-        env:
-          WEBHOOK_URL: ${{ env.GCHAT_WEBHOOK_URL }}
-        run: |
-          curl -X POST -H "Content-Type: application/json" -d '{
-            "text": "🚀 A new pull request has been raised: [${{ github.event.pull_request.title }}](${{ github.event.pull_request.html_url }}) by ${{ github.event.pull_request.user.login }}"
-          }' $WEBHOOK_URL
+    - name: Checkout the repository
+      uses: actions/checkout@v3
 
-      # Notify when PR reviews are fulfilled
-      - name: Check if all reviews are approved
-        if: github.event.action == 'submitted'
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          echo gh api --method GET /repos/siddiqkaithodu/news-summariser/pulls/1/reviews
-          APPROVED_COUNT=$(gh api --header 'Accept: application/vnd.github+json' --method GET /repos/{owner}/{repo}/pulls/{pull_number}/reviews state --jq '[.[] | select(.state=="APPROVED")] | length')
-          REQUIRED_REVIEWS=$(gh repo view --json pullRequests --jq '.pullRequests.nodes[].reviewRequests.totalCount')
-          if [ "$APPROVED_COUNT" -ge "$REQUIRED_REVIEWS" ]; then
-            echo "All required reviews are fulfilled. Proceeding to notify Google Chat."
+    - name: Notify Google Chat
+      env:
+        GOOGLE_CHAT_WEBHOOK: https://chat.googleapis.com/v1/spaces/AAAAu0pPs_8/messages?key=AIzaSyDdI0hCZtE6vySjMm-WEfRq3CPzqKqqsHI&token=2OA68qb_Xv29GMQUPkYHIb2Sm3e3AspjdZ7DAaeNQ0A
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        # Fetch PR details
+        PR_NUMBER=$(jq -r '.pull_request.number' < "$GITHUB_EVENT_PATH")
+        PR_URL=$(jq -r '.pull_request.html_url' < "$GITHUB_EVENT_PATH")
+        PR_TITLE=$(jq -r '.pull_request.title' < "$GITHUB_EVENT_PATH")
+
+        # Get required review count and current review status
+        REPO_OWNER=${{ github.repository_owner }}
+        REPO_NAME=${{ github.event.repository.name }}
+        PR_API_URL="https://api.github.com/repos/${REPO_OWNER}/${REPO_NAME}/pulls/${PR_NUMBER}"
+        REVIEWS_API_URL="https://api.github.com/repos/${REPO_OWNER}/${REPO_NAME}/pulls/${PR_NUMBER}/reviews"
+
+        REQUIRED_REVIEWS=$(curl -s -H "Authorization: Bearer $GITHUB_TOKEN" \
+          -H "Accept: application/vnd.github.v3+json" \
+          $PR_API_URL | jq '.required_reviewers | length')
+
+        CURRENT_APPROVED=$(curl -s -H "Authorization: Bearer $GITHUB_TOKEN" \
+          -H "Accept: application/vnd.github.v3+json" \
+          $REVIEWS_API_URL | jq '[.[] | select(.state == "APPROVED")] | length')
+
+        # Message to Google Chat
+        if [ "${{ github.event.action }}" == "opened" ]; then
+          MESSAGE="A new pull request has been created: *${PR_TITLE}*.\nURL: ${PR_URL}\nReviews Required: ${REQUIRED_REVIEWS}"
+        elif [ "${{ github.event.action }}" == "synchronize" ]; then
+          MESSAGE="The pull request *${PR_TITLE}* has been updated after a review.\nURL: ${PR_URL}"
+        elif [ "${{ github.event.action }}" == "review_submitted" ]; then
+          if [ "$CURRENT_APPROVED" -eq "$REQUIRED_REVIEWS" ]; then
+            MESSAGE="All reviews for *${PR_TITLE}* are complete! You can now merge the code.\nURL: ${PR_URL}"
           else
-            echo "Not all required reviews are fulfilled yet."
+            MESSAGE="A new review has been submitted for *${PR_TITLE}*. Current Approved: ${CURRENT_APPROVED}/${REQUIRED_REVIEWS}\nURL: ${PR_URL}"
           fi
+        fi
 
-      - name: Notify Google Chat to Merge Code
-        if: github.event.action == 'submitted' && env.APPROVED_COUNT >= env.REQUIRED_REVIEWS
-        env:
-          WEBHOOK_URL: ${{ env.GCHAT_WEBHOOK_URL }}
-        run: |
-          curl -X POST -H "Content-Type: application/json" -d '{
-            "text": "✅ All reviews required are fulfilled for PR: [${{ github.event.pull_request.title }}](${{ github.event.pull_request.html_url }}). You can merge the code now!"
-          }' $WEBHOOK_URL
+        # Send message to Google Chat
+        curl -X POST -H "Content-Type: application/json" \
+          -d "{\"text\": \"${MESSAGE}\"}" \
+          "$GOOGLE_CHAT_WEBHOOK"
+
+
+
+
+
+# name: Pull Request Notifications
+# on:
+#   pull_request:
+#     types: [opened, reopened, synchronize, review_requested, ready_for_review, labeled, unlabeled]
+#   pull_request_review:
+#     types:
+#       - submitted
+# env:
+#   requested_reviewers: ${{ toJson(github.event.pull_request.requested_reviewers) }}
+#   GCHAT_WEBHOOK_URL: https://chat.googleapis.com/v1/spaces/AAAAu0pPs_8/messages?key=AIzaSyDdI0hCZtE6vySjMm-WEfRq3CPzqKqqsHI&token=2OA68qb_Xv29GMQUPkYHIb2Sm3e3AspjdZ7DAaeNQ0A
+
+# jobs:
+#   notify-google-chat:
+#     runs-on: ubuntu-latest
+#     steps:
+#       # Notify when a PR is raised
+#       - name: Notify Google Chat about PR Raised
+#         if: github.event.action == 'opened'
+#         env:
+#           WEBHOOK_URL: ${{ env.GCHAT_WEBHOOK_URL }}
+#         run: |
+#           curl -X POST -H "Content-Type: application/json" -d '{
+#             "text": "🚀 A new pull request has been raised: [${{ github.event.pull_request.title }}](${{ github.event.pull_request.html_url }}) by ${{ github.event.pull_request.user.login }}"
+#           }' $WEBHOOK_URL
+
+#       # Notify when PR reviews are fulfilled
+#       - name: Check if all reviews are approved
+#         if: github.event.action == 'submitted'
+#         env:
+#           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+#         run: |
+#           echo gh api --method GET /repos/siddiqkaithodu/news-summariser/pulls/1/reviews
+#           APPROVED_COUNT=$(gh api --header 'Accept: application/vnd.github+json' --method GET /repos/{owner}/{repo}/pulls/{pull_number}/reviews state --jq '[.[] | select(.state=="APPROVED")] | length')
+#           REQUIRED_REVIEWS=$(gh repo view --json pullRequests --jq '.pullRequests.nodes[].reviewRequests.totalCount')
+#           if [ "$APPROVED_COUNT" -ge "$REQUIRED_REVIEWS" ]; then
+#             echo "All required reviews are fulfilled. Proceeding to notify Google Chat."
+#           else
+#             echo "Not all required reviews are fulfilled yet."
+#           fi
+
+#       - name: Notify Google Chat to Merge Code
+#         if: github.event.action == 'submitted' && env.APPROVED_COUNT >= env.REQUIRED_REVIEWS
+#         env:
+#           WEBHOOK_URL: ${{ env.GCHAT_WEBHOOK_URL }}
+#         run: |
+#           curl -X POST -H "Content-Type: application/json" -d '{
+#             "text": "✅ All reviews required are fulfilled for PR: [${{ github.event.pull_request.title }}](${{ github.event.pull_request.html_url }}). You can merge the code now!"
+#           }' $WEBHOOK_URL

--- a/.github/workflows/github-messages.yml
+++ b/.github/workflows/github-messages.yml
@@ -32,7 +32,7 @@ jobs:
             New Pull Request!
             **Repository:** ${{ steps.get_pr_info.outputs.repo_name }}
             **Opened by:** ${{ steps.get_pr_info.outputs.pr_opener }}
-            **Required Approvals:** ${{ steps.get_pr_info.outputs.required_approvals }}
+            **Required Approvals:** ${{ steps.get_pr_info.outputs}}
             
       - name: Wait for Approvals
         uses: actions/github-script@v6

--- a/.github/workflows/github-messages.yml
+++ b/.github/workflows/github-messages.yml
@@ -16,12 +16,11 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
-            const cores = require('@actions/core');
             const pullRequest = context.payload.pull_request;
 
-            cores.setOutput('repo_name', context.repo.repository);
-            cores.setOutput('pr_opener', pullRequest.user.login);
-            cores.setOutput('required_approvals', pullRequest.required_approvals_review);
+            core.setOutput('repo_name', context.repo.repository);
+            core.setOutput('pr_opener', pullRequest.user.login);
+            core.setOutput('required_approvals', pullRequest.required_approvals_review);
 
       - name: Post Google Chat message
         uses: julb/action-post-googlechat-message@v1
@@ -37,10 +36,9 @@ jobs:
         uses: actions/github-script@v6
         with:
           script: |
-            const cores = require('@actions/core');
             const pullRequest = context.payload.pull_request;
 
-            cores.setOutput('approvals_count', pullRequest.reviews.filter(review => review.state === 'APPROVED').length);
+            core.setOutput('approvals_count', pullRequest.reviews.filter(review => review.state === 'APPROVED').length);
 
       - name: Send Approval Updates
         uses: julb/action-post-googlechat-message@v1

--- a/.github/workflows/github-messages.yml
+++ b/.github/workflows/github-messages.yml
@@ -32,7 +32,7 @@ jobs:
             New Pull Request!
             **Repository:** ${{ steps.get_pr_info.outputs.repo_name }}
             **Opened by:** ${{ steps.get_pr_info.outputs.pr_opener }}
-            **Required Approvals:** ${{ toJson(steps.get_pr_info) }}
+            **Required Approvals:** ${{ toJson(steps) }}
             
       - name: Wait for Approvals
         uses: actions/github-script@v6

--- a/.github/workflows/github-messages.yml
+++ b/.github/workflows/github-messages.yml
@@ -29,20 +29,19 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          echo ${{ toJson(github.event.pull_request) }}
-          # APPROVED_COUNT=$(gh pr review ${{ github.event.pull_request.number }} state --jq '[.[] | select(.state=="APPROVED")] | length')
-          # REQUIRED_REVIEWS=$(gh repo view --json pullRequests --jq '.pullRequests.nodes[].reviewRequests.totalCount')
-          # if [ "$APPROVED_COUNT" -ge "$REQUIRED_REVIEWS" ]; then
-          #   echo "All required reviews are fulfilled. Proceeding to notify Google Chat."
-          # else
-          #   echo "Not all required reviews are fulfilled yet."
-          # fi
+          APPROVED_COUNT=$(gh pr review ${{ github.event.pull_request.number }} state --jq '[.[] | select(.state=="APPROVED")] | length')
+          REQUIRED_REVIEWS=$(gh repo view --json pullRequests --jq '.pullRequests.nodes[].reviewRequests.totalCount')
+          if [ "$APPROVED_COUNT" -ge "$REQUIRED_REVIEWS" ]; then
+            echo "All required reviews are fulfilled. Proceeding to notify Google Chat."
+          else
+            echo "Not all required reviews are fulfilled yet."
+          fi
 
-      # - name: Notify Google Chat to Merge Code
-      #   if: github.event.action == 'submitted' && env.APPROVED_COUNT >= REQUIRED_REVIEWS
-      #   env:
-      #     WEBHOOK_URL: ${{ env.GCHAT_WEBHOOK_URL }}
-      #   run: |
-      #     curl -X POST -H "Content-Type: application/json" -d '{
-      #       "text": "✅ All reviews required are fulfilled for PR: [${{ github.event.pull_request.title }}](${{ github.event.pull_request.html_url }}). You can merge the code now!"
-      #     }' $WEBHOOK_URL
+      - name: Notify Google Chat to Merge Code
+        if: github.event.action == 'submitted' && env.APPROVED_COUNT >= env.REQUIRED_REVIEWS
+        env:
+          WEBHOOK_URL: ${{ env.GCHAT_WEBHOOK_URL }}
+        run: |
+          curl -X POST -H "Content-Type: application/json" -d '{
+            "text": "✅ All reviews required are fulfilled for PR: [${{ github.event.pull_request.title }}](${{ github.event.pull_request.html_url }}). You can merge the code now!"
+          }' $WEBHOOK_URL

--- a/.github/workflows/github-messages.yml
+++ b/.github/workflows/github-messages.yml
@@ -29,7 +29,8 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          APPROVED_COUNT=$(gh pr review ${{ github.event.pull_request.number }} state --jq '[.[] | select(.state=="APPROVED")] | length')
+        
+          APPROVED_COUNT=$(gh api --header 'Accept: application/vnd.github+json' --method GET /repos/{owner}/{repo}/pulls/{pull_number}/reviews state --jq '[.[] | select(.state=="APPROVED")] | length')
           REQUIRED_REVIEWS=$(gh repo view --json pullRequests --jq '.pullRequests.nodes[].reviewRequests.totalCount')
           if [ "$APPROVED_COUNT" -ge "$REQUIRED_REVIEWS" ]; then
             echo "All required reviews are fulfilled. Proceeding to notify Google Chat."

--- a/.github/workflows/github-messages.yml
+++ b/.github/workflows/github-messages.yml
@@ -1,4 +1,6 @@
 name: Pull Request Notifications
+env:
+  GCHAT_WEBHOOK_URL: https://chat.googleapis.com/v1/spaces/AAAAu0pPs_8/messages?key=AIzaSyDdI0hCZtE6vySjMm-WEfRq3CPzqKqqsHI&token=2OA68qb_Xv29GMQUPkYHIb2Sm3e3AspjdZ7DAaeNQ0A
 
 on:
   pull_request:
@@ -25,7 +27,7 @@ jobs:
       - name: Post Google Chat message
         uses: julb/action-post-googlechat-message@v1
         with:
-          gchat_webhook_url: ${{ secrets.GCHAT_WEBHOOK_URL }}
+          gchat_webhook_url: ${{ GCHAT_WEBHOOK_URL }}
           message:
             New Pull Request!
             * **Repository:** ${{ steps.get_pr_info.outputs.repo_name }}
@@ -43,7 +45,7 @@ jobs:
       - name: Send Approval Update
         uses: julb/action-post-googlechat-message@v1
         with:
-          gchat_webhook_url: ${{ secrets.GCHAT_WEBHOOK_URL }}
+          gchat_webhook_url: ${{ GCHAT_WEBHOOK_URL }}
           if: steps.wait_for_approvals.outputs.approvals_count > 0 && steps.wait_for_approvals.outputs.approvals_count < pullRequest.required_approvals_review
           message: |
             Pull Request Update!
@@ -53,7 +55,7 @@ jobs:
       - name: Send Merge Notification
         uses: julb/action-post-googlechat-message@v1
         with:
-          gchat_webhook_url: ${{ secrets.GCHAT_WEBHOOK_URL }}
+          gchat_webhook_url: ${{ GCHAT_WEBHOOK_URL }}
           if: $ {{steps.wait_for_approvals.outputs.approvals_count == pullRequest.required_approvals_review }}
           message: |
             🎉 Pull Request Ready to Merge! 🎉

--- a/.github/workflows/github-messages.yml
+++ b/.github/workflows/github-messages.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Post Google Chat message
         uses: julb/action-post-googlechat-message@v1
         with:
-          gchat_webhook_url: ${{ GCHAT_WEBHOOK_URL }}
+          gchat_webhook_url: ${{ env.GCHAT_WEBHOOK_URL }}
           message:
             New Pull Request!
             * **Repository:** ${{ steps.get_pr_info.outputs.repo_name }}
@@ -45,7 +45,7 @@ jobs:
       - name: Send Approval Update
         uses: julb/action-post-googlechat-message@v1
         with:
-          gchat_webhook_url: ${{ GCHAT_WEBHOOK_URL }}
+          gchat_webhook_url: ${{ env.GCHAT_WEBHOOK_URL }}
           if: steps.wait_for_approvals.outputs.approvals_count > 0 && steps.wait_for_approvals.outputs.approvals_count < pullRequest.required_approvals_review
           message: |
             Pull Request Update!
@@ -55,7 +55,7 @@ jobs:
       - name: Send Merge Notification
         uses: julb/action-post-googlechat-message@v1
         with:
-          gchat_webhook_url: ${{ GCHAT_WEBHOOK_URL }}
+          gchat_webhook_url: ${{ env.GCHAT_WEBHOOK_URL }}
           if: $ {{steps.wait_for_approvals.outputs.approvals_count == pullRequest.required_approvals_review }}
           message: |
             🎉 Pull Request Ready to Merge! 🎉

--- a/.github/workflows/github-messages.yml
+++ b/.github/workflows/github-messages.yml
@@ -13,7 +13,7 @@ jobs:
 
       - name: Get PR Information
         id: get_pr_info
-        uses: actions/github-script@v6
+        uses: actions/github-script@v7
         with:
           script: |
             const github = require('@actions/github');
@@ -62,7 +62,7 @@ jobs:
         uses: julb/action-post-googlechat-message@v1
         with:
           gchat_webhook_url: ${{ secrets.GCHAT_WEBHOOK_URL }}
-          if: steps.wait_for_approvals.outputs.approvals_count == pullRequest.required_approvals_review
+          if: $ {{steps.wait_for_approvals.outputs.approvals_count == pullRequest.required_approvals_review }}
           message: |
             🎉 Pull Request Ready to Merge! 🎉
             * **Repository:** ${{ steps.get_pr_info.outputs.repo_name }}

--- a/.github/workflows/github-messages.yml
+++ b/.github/workflows/github-messages.yml
@@ -32,7 +32,7 @@ jobs:
             New Pull Request!
             **Repository:** ${{ steps.get_pr_info.outputs.repo_name }}
             **Opened by:** ${{ steps.get_pr_info.outputs.pr_opener }}
-            **Required Approvals:** ${{ fromJson(steps.get_pr_info.outputs) }}
+            **Required Approvals:** ${{ steps.get_pr_info.outputs }}
             
       - name: Wait for Approvals
         uses: actions/github-script@v6

--- a/.github/workflows/github-messages.yml
+++ b/.github/workflows/github-messages.yml
@@ -17,14 +17,14 @@ jobs:
         with:
           script: |
             const github_instance = require('@actions/github');
-            const core = require('@actions/core');
+            const cores = require('@actions/core');
 
             const { context } = github_instance;
             const pullRequest = context.payload.pull_request;
 
-            core.setOutput('repo_name', context.repo.repository);
-            core.setOutput('pr_opener', pullRequest.user.login);
-            core.setOutput('required_approvals', pullRequest.required_approvals_review);
+            cores.setOutput('repo_name', context.repo.repository);
+            cores.setOutput('pr_opener', pullRequest.user.login);
+            cores.setOutput('required_approvals', pullRequest.required_approvals_review);
 
       - name: Post Google Chat message
         uses: julb/action-post-googlechat-message@v1
@@ -41,12 +41,12 @@ jobs:
         with:
           script: |
             const github_instance = require('@actions/github');
-            const core = require('@actions/core');
+            const cores = require('@actions/core');
 
             const { context } = github_instance;
             const pullRequest = context.payload.pull_request;
 
-            core.setOutput('approvals_count', pullRequest.reviews.filter(review => review.state === 'APPROVED').length);
+            cores.setOutput('approvals_count', pullRequest.reviews.filter(review => review.state === 'APPROVED').length);
 
       - name: Send Approval Updates
         uses: julb/action-post-googlechat-message@v1

--- a/.github/workflows/github-messages.yml
+++ b/.github/workflows/github-messages.yml
@@ -16,7 +16,6 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
-            const github_instance = require('@actions/github');
             const cores = require('@actions/core');
             const pullRequest = context.payload.pull_request;
 
@@ -38,7 +37,6 @@ jobs:
         uses: actions/github-script@v6
         with:
           script: |
-            const github_instance = require('@actions/github');
             const cores = require('@actions/core');
             const pullRequest = context.payload.pull_request;
 

--- a/.github/workflows/github-messages.yml
+++ b/.github/workflows/github-messages.yml
@@ -1,19 +1,13 @@
 name: Pull Request Notifications
-env:
-  REQUIRED_REVIEWS: 2
-  GCHAT_WEBHOOK_URL: https://chat.googleapis.com/v1/spaces/AAAAu0pPs_8/messages?key=AIzaSyDdI0hCZtE6vySjMm-WEfRq3CPzqKqqsHI&token=2OA68qb_Xv29GMQUPkYHIb2Sm3e3AspjdZ7DAaeNQ0A
-
-# on:
-#   pull_request:
-#     types: [opened, reopened, synchronize, review_requested, ready_for_review, labeled, unlabeled]
-# name: Notify Google Chat on Pull Request
-
 on:
   pull_request:
     types: [opened, reopened, synchronize, review_requested, ready_for_review, labeled, unlabeled]
   pull_request_review:
     types:
       - submitted
+env:
+  REQUIRED_REVIEWS: 2
+  GCHAT_WEBHOOK_URL: https://chat.googleapis.com/v1/spaces/AAAAu0pPs_8/messages?key=AIzaSyDdI0hCZtE6vySjMm-WEfRq3CPzqKqqsHI&token=2OA68qb_Xv29GMQUPkYHIb2Sm3e3AspjdZ7DAaeNQ0A
 
 jobs:
   notify-google-chat:
@@ -35,7 +29,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          APPROVED_COUNT=$(gh pr reviews ${{ github.event.pull_request.number }} --json state --jq '[.[] | select(.state=="APPROVED")] | length')
+          APPROVED_COUNT=$(gh pr reviews ${{ github.event.pull_request.number }} state --jq '[.[] | select(.state=="APPROVED")] | length')
           REQUIRED_REVIEWS=$(gh repo view --json pullRequests --jq '.pullRequests.nodes[].reviewRequests.totalCount')
           if [ "$APPROVED_COUNT" -ge "$REQUIRED_REVIEWS" ]; then
             echo "All required reviews are fulfilled. Proceeding to notify Google Chat."

--- a/.github/workflows/github-messages.yml
+++ b/.github/workflows/github-messages.yml
@@ -30,9 +30,9 @@ jobs:
           gchat_webhook_url: ${{ env.GCHAT_WEBHOOK_URL }}
           message:
             New Pull Request!
-            * **Repository:** ${{ steps.get_pr_info.outputs.repo_name }}
-            * **Opened by:** ${{ steps.get_pr_info.outputs.pr_opener }}
-            * **Required Approvals:** ${{ steps.get_pr_info.outputs.required_approvals }}
+            **Repository:** ${{ steps.get_pr_info.outputs.repo_name }}
+            **Opened by:** ${{ steps.get_pr_info.outputs.pr_opener }}
+            **Required Approvals:** ${{ steps.get_pr_info.outputs.required_approvals }}
             
       - name: Wait for Approvals
         uses: actions/github-script@v6

--- a/.github/workflows/github-messages.yml
+++ b/.github/workflows/github-messages.yml
@@ -16,10 +16,10 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
-            const github = require('@actions/github');
+            const github_instance = require('@actions/github');
             const core = require('@actions/core');
 
-            const { context } = github;
+            const { context } = github_instance;
             const pullRequest = context.payload.pull_request;
 
             core.setOutput('repo_name', context.repo.repository);
@@ -40,10 +40,10 @@ jobs:
         uses: actions/github-script@v6
         with:
           script: |
-            const github = require('@actions/github');
+            const github_instance = require('@actions/github');
             const core = require('@actions/core');
 
-            const { context } = github;
+            const { context } = github_instance;
             const pullRequest = context.payload.pull_request;
 
             core.setOutput('approvals_count', pullRequest.reviews.filter(review => review.state === 'APPROVED').length);

--- a/.github/workflows/github-messages.yml
+++ b/.github/workflows/github-messages.yml
@@ -38,11 +38,11 @@ jobs:
           #   echo "Not all required reviews are fulfilled yet."
           # fi
 
-      - name: Notify Google Chat to Merge Code
-        if: github.event.action == 'submitted' && env.APPROVED_COUNT >= REQUIRED_REVIEWS
-        env:
-          WEBHOOK_URL: ${{ env.GCHAT_WEBHOOK_URL }}
-        run: |
-          curl -X POST -H "Content-Type: application/json" -d '{
-            "text": "✅ All reviews required are fulfilled for PR: [${{ github.event.pull_request.title }}](${{ github.event.pull_request.html_url }}). You can merge the code now!"
-          }' $WEBHOOK_URL
+      # - name: Notify Google Chat to Merge Code
+      #   if: github.event.action == 'submitted' && env.APPROVED_COUNT >= REQUIRED_REVIEWS
+      #   env:
+      #     WEBHOOK_URL: ${{ env.GCHAT_WEBHOOK_URL }}
+      #   run: |
+      #     curl -X POST -H "Content-Type: application/json" -d '{
+      #       "text": "✅ All reviews required are fulfilled for PR: [${{ github.event.pull_request.title }}](${{ github.event.pull_request.html_url }}). You can merge the code now!"
+      #     }' $WEBHOOK_URL

--- a/.github/workflows/github-messages.yml
+++ b/.github/workflows/github-messages.yml
@@ -29,7 +29,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          echo gh api --header 'Accept: application/vnd.github+json' --method GET /repos/{owner}/{repo}/pulls/{pull_number}/reviews
+          echo gh api --method GET /repos/siddiqkaithodu/news-summariser/pulls/1/reviews
           APPROVED_COUNT=$(gh api --header 'Accept: application/vnd.github+json' --method GET /repos/{owner}/{repo}/pulls/{pull_number}/reviews state --jq '[.[] | select(.state=="APPROVED")] | length')
           REQUIRED_REVIEWS=$(gh repo view --json pullRequests --jq '.pullRequests.nodes[].reviewRequests.totalCount')
           if [ "$APPROVED_COUNT" -ge "$REQUIRED_REVIEWS" ]; then

--- a/.github/workflows/github-messages.yml
+++ b/.github/workflows/github-messages.yml
@@ -1,5 +1,6 @@
 name: Pull Request Notifications
 env:
+  REQUIRED_REVIEWS: 2
   GCHAT_WEBHOOK_URL: https://chat.googleapis.com/v1/spaces/AAAAu0pPs_8/messages?key=AIzaSyDdI0hCZtE6vySjMm-WEfRq3CPzqKqqsHI&token=2OA68qb_Xv29GMQUPkYHIb2Sm3e3AspjdZ7DAaeNQ0A
 
 # on:

--- a/.github/workflows/github-messages.yml
+++ b/.github/workflows/github-messages.yml
@@ -1,0 +1,69 @@
+name: Pull Request Notifications
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize, review_requested, ready_for_review, labeled, unlabeled]
+
+jobs:
+  notify_on_pr:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Get PR Information
+        id: get_pr_info
+        uses: actions/github-script@v6
+        with:
+          script: |
+            const github = require('@actions/github');
+            const core = require('@actions/core');
+
+            const { context } = github;
+            const pullRequest = context.payload.pull_request;
+
+            core.setOutput('repo_name', context.repo.repository);
+            core.setOutput('pr_opener', pullRequest.user.login);
+            core.setOutput('required_approvals', pullRequest.required_approvals_review);
+
+      - name: Post Google Chat message
+        uses: julb/action-post-googlechat-message@v1
+        with:
+          gchat_webhook_url: ${{ secrets.GCHAT_WEBHOOK_URL }}
+          message:
+            New Pull Request!
+            * **Repository:** ${{ steps.get_pr_info.outputs.repo_name }}
+            * **Opened by:** ${{ steps.get_pr_info.outputs.pr_opener }}
+            * **Required Approvals:** ${{ steps.get_pr_info.outputs.required_approvals }}
+            
+      - name: Wait for Approvals
+        uses: actions/github-script@v6
+        with:
+          script: |
+            const github = require('@actions/github');
+            const core = require('@actions/core');
+
+            const { context } = github;
+            const pullRequest = context.payload.pull_request;
+
+            core.setOutput('approvals_count', pullRequest.reviews.filter(review => review.state === 'APPROVED').length);
+
+      - name: Send Approval Updates
+        uses: julb/action-post-googlechat-message@v1
+        with:
+          gchat_webhook_url: ${{ secrets.GCHAT_WEBHOOK_URL }}
+          if: steps.wait_for_approvals.outputs.approvals_count > 0 && steps.wait_for_approvals.outputs.approvals_count < pullRequest.required_approvals_review
+          message: |
+            Pull Request Update!
+            * **Repository:** ${{ steps.get_pr_info.outputs.repo_name }}
+            * **Current Approvals:** ${{ steps.wait_for_approvals.outputs.approvals_count }} / ${{ steps.get_pr_info.outputs.required_approvals }}
+
+      - name: Send Merge Notification
+        uses: julb/action-post-googlechat-message@v1
+        with:
+          gchat_webhook_url: ${{ secrets.GCHAT_WEBHOOK_URL }}
+          if: steps.wait_for_approvals.outputs.approvals_count == pullRequest.required_approvals_review
+          message: |
+            🎉 Pull Request Ready to Merge! 🎉
+            * **Repository:** ${{ steps.get_pr_info.outputs.repo_name }}
+            * **Opened by:** ${{ steps.get_pr_info.outputs.pr_opener }}

--- a/.github/workflows/github-messages.yml
+++ b/.github/workflows/github-messages.yml
@@ -18,8 +18,6 @@ jobs:
           script: |
             const github_instance = require('@actions/github');
             const cores = require('@actions/core');
-
-            const { context } = github_instance;
             const pullRequest = context.payload.pull_request;
 
             cores.setOutput('repo_name', context.repo.repository);
@@ -42,8 +40,6 @@ jobs:
           script: |
             const github_instance = require('@actions/github');
             const cores = require('@actions/core');
-
-            const { context } = github_instance;
             const pullRequest = context.payload.pull_request;
 
             cores.setOutput('approvals_count', pullRequest.reviews.filter(review => review.state === 'APPROVED').length);

--- a/.github/workflows/github-messages.yml
+++ b/.github/workflows/github-messages.yml
@@ -2,62 +2,53 @@ name: Pull Request Notifications
 env:
   GCHAT_WEBHOOK_URL: https://chat.googleapis.com/v1/spaces/AAAAu0pPs_8/messages?key=AIzaSyDdI0hCZtE6vySjMm-WEfRq3CPzqKqqsHI&token=2OA68qb_Xv29GMQUPkYHIb2Sm3e3AspjdZ7DAaeNQ0A
 
+# on:
+#   pull_request:
+#     types: [opened, reopened, synchronize, review_requested, ready_for_review, labeled, unlabeled]
+# name: Notify Google Chat on Pull Request
+
 on:
   pull_request:
-    types: [opened, reopened, synchronize, review_requested, ready_for_review, labeled, unlabeled]
+    types:
+      - opened
+      - closed
+  pull_request_review:
+    types:
+      - submitted
 
 jobs:
-  notify_on_pr:
+  notify-google-chat:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
+      # Notify when a PR is raised
+      - name: Notify Google Chat about PR Raised
+        if: github.event.action == 'opened'
+        env:
+          WEBHOOK_URL: ${{ env.GCHAT_WEBHOOK_URL }}
+        run: |
+          curl -X POST -H "Content-Type: application/json" -d '{
+            "text": "🚀 A new pull request has been raised: [${{ github.event.pull_request.title }}](${{ github.event.pull_request.html_url }}) by ${{ github.event.pull_request.user.login }}"
+          }' $WEBHOOK_URL
 
-      - name: Get PR Information
-        id: get_pr_info
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const pullRequest = context.payload.pull_request;
+      # Notify when PR reviews are fulfilled
+      - name: Check if all reviews are approved
+        if: github.event.action == 'submitted'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          APPROVED_COUNT=$(gh pr reviews ${{ github.event.pull_request.number }} --json state --jq '[.[] | select(.state=="APPROVED")] | length')
+          REQUIRED_REVIEWS=$(gh repo view --json pullRequests --jq '.pullRequests.nodes[].reviewRequests.totalCount')
+          if [ "$APPROVED_COUNT" -ge "$REQUIRED_REVIEWS" ]; then
+            echo "All required reviews are fulfilled. Proceeding to notify Google Chat."
+          else
+            echo "Not all required reviews are fulfilled yet."
+          fi
 
-            core.setOutput('repo_name', context.repo.repository);
-            core.setOutput('pr_opener', pullRequest.user.login);
-            core.setOutput('required_approvals', pullRequest.required_approvals_review);
-
-      - name: Post Google Chat message
-        uses: julb/action-post-googlechat-message@v1
-        with:
-          gchat_webhook_url: ${{ env.GCHAT_WEBHOOK_URL }}
-          message: |
-            New Pull Request!
-            **Repository:** ${{ steps.get_pr_info.outputs.repo_name }}
-            **Opened by:** ${{ steps.get_pr_info.outputs.pr_opener }}
-            **Required Approvals:** ${{ toJson(steps) }}
-            
-      - name: Wait for Approvals
-        uses: actions/github-script@v6
-        with:
-          script: |
-            const pullRequest = context.payload.pull_request;
-
-            core.setOutput('approvals_count', pullRequest.reviews.filter(review => review.state === 'APPROVED').length);
-
-      - name: Send Approval Update
-        uses: julb/action-post-googlechat-message@v1
-        with:
-          gchat_webhook_url: ${{ env.GCHAT_WEBHOOK_URL }}
-          if: steps.wait_for_approvals.outputs.approvals_count > 0 && steps.wait_for_approvals.outputs.approvals_count < pullRequest.required_approvals_review
-          message: |
-            Pull Request Update!
-            * **Repository:** ${{ steps.get_pr_info.outputs.repo_name }}
-            * **Current Approvals:** ${{ steps.wait_for_approvals.outputs.approvals_count }} / ${{ steps.get_pr_info.outputs.required_approvals }}
-
-      - name: Send Merge Notification
-        uses: julb/action-post-googlechat-message@v1
-        with:
-          gchat_webhook_url: ${{ env.GCHAT_WEBHOOK_URL }}
-          if: $ {{steps.wait_for_approvals.outputs.approvals_count == pullRequest.required_approvals_review }}
-          message: |
-            🎉 Pull Request Ready to Merge! 🎉
-            * **Repository:** ${{ steps.get_pr_info.outputs.repo_name }}
-            * **Opened by:** ${{ steps.get_pr_info.outputs.pr_opener }}
+      - name: Notify Google Chat to Merge Code
+        if: github.event.action == 'submitted' && env.APPROVED_COUNT >= env.REQUIRED_REVIEWS
+        env:
+          WEBHOOK_URL: ${{ env.GCHAT_WEBHOOK_URL }}
+        run: |
+          curl -X POST -H "Content-Type: application/json" -d '{
+            "text": "✅ All reviews required are fulfilled for PR: [${{ github.event.pull_request.title }}](${{ github.event.pull_request.html_url }}). You can merge the code now!"
+          }' $WEBHOOK_URL


### PR DESCRIPTION
testing

## Summary by Sourcery

Add a GitHub Actions workflow to send Google Chat messages for pull request events.

New Features:
- Post Google Chat messages for pull request updates, including the number of approvals.

CI:
- Set up a GitHub Actions workflow to post messages to Google Chat for pull request events like opening, reopening, syncing, review requests, ready for review, labeling, and unlabeling.